### PR TITLE
fix(monorepo): stabilize Windows workspace paths

### DIFF
--- a/.changeset/fix-windows-workspace-paths.md
+++ b/.changeset/fix-windows-workspace-paths.md
@@ -1,0 +1,5 @@
+---
+"@icebreakers/monorepo": patch
+---
+
+Stabilize workspace package discovery and config inspection on Windows short paths.

--- a/packages/monorepo/src/core/config.ts
+++ b/packages/monorepo/src/core/config.ts
@@ -51,8 +51,14 @@ async function loadConfigInternal(cwd: string): Promise<LoadedMonorepoConfig> {
     packageJson: false,
   })
 
+  const matchedConfigFile = configFile && fs.existsSync(configFile)
+    ? findConfigFiles(cwd, configName).find(file => path.basename(file).toLowerCase() === path.basename(configFile).toLowerCase())
+    : undefined
+
   return {
-    file: configFile && fs.existsSync(configFile) ? fs.realpathSync(configFile) : null,
+    file: matchedConfigFile
+      ? fs.realpathSync(matchedConfigFile)
+      : (configFile && fs.existsSync(configFile) ? fs.realpathSync(configFile) : null),
     config: config ?? {},
   }
 }

--- a/packages/monorepo/src/core/config.ts
+++ b/packages/monorepo/src/core/config.ts
@@ -1,5 +1,6 @@
 import type { MonorepoConfig } from '../types'
 import fs from 'node:fs'
+import { realpath } from 'node:fs/promises'
 import { loadConfig } from 'c12'
 import path from 'pathe'
 
@@ -57,8 +58,8 @@ async function loadConfigInternal(cwd: string): Promise<LoadedMonorepoConfig> {
 
   return {
     file: matchedConfigFile
-      ? fs.realpathSync(matchedConfigFile)
-      : (configFile && fs.existsSync(configFile) ? fs.realpathSync(configFile) : null),
+      ? await realpath(matchedConfigFile)
+      : (configFile && fs.existsSync(configFile) ? await realpath(configFile) : null),
     config: config ?? {},
   }
 }

--- a/packages/monorepo/src/core/workspace.ts
+++ b/packages/monorepo/src/core/workspace.ts
@@ -25,6 +25,10 @@ function comparePackagePath(left: WorkspacePackageSummary, right: WorkspacePacka
   return left.relativeDir.localeCompare(right.relativeDir)
 }
 
+function getPackageRootDir(project: WorkspacePackage) {
+  return normalizeDir(project.rootDirRealPath || project.rootDir)
+}
+
 async function findWorkspaceDirCached(cwd: string) {
   const key = normalizeDir(cwd)
   if (!workspaceDirCache.has(key)) {
@@ -98,9 +102,11 @@ export async function getWorkspacePackages(
     }
     return true
   }).map((project) => {
-    const pkgJsonPath = path.resolve(project.rootDir, 'package.json')
+    const rootDir = getPackageRootDir(project)
+    const pkgJsonPath = path.resolve(rootDir, 'package.json')
     return {
       ...project,
+      rootDir,
       pkgJsonPath,
     }
   })

--- a/packages/monorepo/test/core/workspace.test.ts
+++ b/packages/monorepo/test/core/workspace.test.ts
@@ -27,6 +27,24 @@ describe('workspace helpers', () => {
     expect(findWorkspacePackagesMock).toHaveBeenCalledWith('/repo', { patterns: ['packages/*'] })
   })
 
+  it('filters out the root package when pnpm reports a short root path', async () => {
+    const findWorkspacePackagesMock = vi.fn(async () => [
+      { rootDir: '/RUNNER~1/repo', manifest: { name: 'root', private: false }, rootDirRealPath: '/runneradmin/repo' },
+      { rootDir: '/runneradmin/repo/packages/a', manifest: { name: 'pkg-a', private: false }, rootDirRealPath: '/runneradmin/repo/packages/a' },
+    ])
+    const readManifestMock = vi.fn(async () => ({ packages: ['packages/*'] }))
+
+    vi.doMock('@pnpm/workspace.find-packages', () => ({ findWorkspacePackages: findWorkspacePackagesMock }))
+    vi.doMock('@pnpm/workspace.read-manifest', () => ({ readWorkspaceManifest: readManifestMock }))
+    vi.doMock('@pnpm/find-workspace-dir', () => ({ findWorkspaceDir: vi.fn(async () => '/runneradmin/repo') }))
+
+    const { getWorkspacePackages } = await import('@/core/workspace')
+    const result = await getWorkspacePackages('/runneradmin/repo', { ignorePrivatePackage: false })
+
+    expect(result.map(pkg => pkg.manifest.name)).toEqual(['pkg-a'])
+    expect(result[0]?.rootDir).toBe('/runneradmin/repo/packages/a')
+  })
+
   it('keeps root and private packages when options request them', async () => {
     const findWorkspacePackagesMock = vi.fn(async () => [
       { rootDir: '/repo', manifest: { name: 'root', private: false }, rootDirRealPath: '/repo' },


### PR DESCRIPTION
## Summary
- normalize pnpm workspace package roots using real paths before root-package filtering
- return stable config inspection file paths when Windows short paths are involved
- add a regression test for short root paths

## Verification
- pnpm build
- pnpm --dir packages/monorepo exec vitest run test/core/workspace.test.ts test/commands/config.test.ts test/commands/env.test.ts test/commands/doctor.test.ts
- pre-push ran pnpm lint and pnpm typecheck